### PR TITLE
修复Linux环境下无法合成视频的问题

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,13 +1,19 @@
 import launch
+import platform
+
+
+plat = platform.system().lower()
 
 
 if not launch.is_installed("cv2"):
     print('Installing requirements for Mov2mov')
     launch.run_pip("install opencv-python", "requirements for opencv")
-    launch.run_pip("install imageio", "requirements for imageio")
+    if plat == 'linux':
+        launch.run_pip("install imageio", "requirements for imageio")
 
 
 if not launch.is_installed('ffmpeg'):
     print('Installing requirements for Mov2mov')
     launch.run_pip("install ffmpeg", "requirements for ffmpeg")
-    launch.run_pip("install install imageio-ffmpeg", "requirements for imageio-ffmpeg")
+    if plat == 'linux':
+        launch.run_pip("install install imageio-ffmpeg", "requirements for imageio-ffmpeg")

--- a/install.py
+++ b/install.py
@@ -4,7 +4,10 @@ import launch
 if not launch.is_installed("cv2"):
     print('Installing requirements for Mov2mov')
     launch.run_pip("install opencv-python", "requirements for opencv")
+    launch.run_pip("install imageio", "requirements for imageio")
+
 
 if not launch.is_installed('ffmpeg'):
     print('Installing requirements for Mov2mov')
     launch.run_pip("install ffmpeg", "requirements for ffmpeg")
+    launch.run_pip("install install imageio-ffmpeg", "requirements for imageio-ffmpeg")

--- a/scripts/m2m_util.py
+++ b/scripts/m2m_util.py
@@ -62,21 +62,28 @@ def get_mov_all_images(file, frames):
     cap.release()
     return image_list
 
-
-def images_to_video(images, frames, mode, w, h, out_path):
+def images_to_video(images, frames, mode, codec, w, h, out_path):
     # 判断out_path是否存在,不存在则创建
     if not os.path.exists(os.path.dirname(out_path)):
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
-
-    fourcc = cv2.VideoWriter_fourcc(*mode)
-    if len(images) > 0:
-        img = images[0]
-        img_width, img_height = img.size
-        w = img_width
-        h = img_height
-    video = cv2.VideoWriter(out_path, fourcc, frames, (w, h))
-    for image in images:
-        img = cv2.cvtColor(numpy.asarray(image), cv2.COLOR_RGB2BGR)
-        video.write(img)
-    video.release()
+    try:
+        fourcc = cv2.VideoWriter_fourcc(*mode)
+        if len(images) > 0:
+            img = images[0]
+            img_width, img_height = img.size
+            w = img_width
+            h = img_height
+        video = cv2.VideoWriter(out_path, fourcc, frames, (w, h))
+        for image in images:
+            img = cv2.cvtColor(numpy.asarray(image), cv2.COLOR_RGB2BGR)
+            video.write(img)
+        video.release()
+    except Exception as e:
+        print(e)
+        print("Try another mode.")
+        video = imageio.v2.get_writer(out_path, format='ffmpeg', mode='I', fps=frames, codec=codec)
+        for image in images:
+            img = imageio.imread(image)
+            video.append_data(img)
+        video.close()
     return out_path

--- a/scripts/mov2mov.py
+++ b/scripts/mov2mov.py
@@ -130,17 +130,20 @@ def process_mov2mov(p, mov_file, movie_frames, max_frames, resize_mode, w, h, ge
     if generate_mov_mode == 0:
         r_f = '.mp4'
         mode = 'mp4v'
+        codec = 'libx264'
     elif generate_mov_mode == 1:
         r_f = '.mp4'
         mode = 'avc1'
+        codec = 'libx264'
     elif generate_mov_mode == 2:
         r_f = '.avi'
         mode = 'XVID'
+        codec = 'libxvid'
 
     print(f'Start generating {r_f} file')
 
-    video = images_to_video(generate_images, movie_frames, mode, w, h,
-                            os.path.join(shared.opts.data.get("mov2mov_output_dir", mov2mov_output_dir),
+    video = images_to_video(generate_images, movie_frames, mode, codec=codec, w=w, h=h,
+                            out_path=os.path.join(shared.opts.data.get("mov2mov_output_dir", mov2mov_output_dir),
                                          str(int(time.time())) + r_f, ))
     print(f'The generation is complete, the directory::{video}')
 


### PR DESCRIPTION
原始方法无法创建VideoWriter: VIDEOIO/FFMPEG: Failed to initialize VideoWriter
具体错误如下：
```
[ERROR:0@4745.524] global cap_ffmpeg_impl.hpp:2991 open Could not find encoder for codec_id=27, error: Encoder not found
[ERROR:0@4745.524] global cap_ffmpeg_impl.hpp:3066 open VIDEOIO/FFMPEG: Failed to initialize VideoWriter
[ERROR:0@4745.532] global cap.cpp:595 open VIDEOIO(CV_IMAGES): raised OpenCV exception:

OpenCV(4.7.0) /io/opencv/modules/videoio/src/cap_images.cpp:267: error: (-215:Assertion failed) number < max_number in function 'icvExtractPattern'
```

原因是因为opencv-python官方发布的Linux版本的二进制wheels无法按照opencv的开源协议进行发布，因此Linux版本必须是用户自己进行源码编译才能使用cv2.VideoWriter()方法

具体原因请看opencv-python官方repo的issue中的官方回复：https://github.com/opencv/opencv-python/issues/207

因此本request添加了imageio库的方法进行了备用使用了try-exception方法添加。具体请看代码变更