### PR TITLE
Fix NameError: name 'imageio' is not defined

### DIFF
--- a/scripts/m2m_util.py
+++ b/scripts/m2m_util.py
@@ -2,6 +2,7 @@ import os.path
 
 import cv2
 import numpy
+import imageio
 
 
 def video_to_images(frames, video_path, out_path):


### PR DESCRIPTION
粗心的 @Looong01 老哥没有引入 imageio 模块就调用对应方法，导致程序报错。本地导入 imageio 模块后程序正常运行。