### PR TITLE
Fix ImportError: The `FFMPEG` plugin is not installed.

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,14 +1,10 @@
 import launch
 
-
-plat = platform.system().lower()
-
-
 if not launch.is_installed("cv2"):
     print('Installing requirements for Mov2mov')
     launch.run_pip("install opencv-python", "requirements for opencv")
     launch.run_pip("install imageio", "requirements for imageio")
-
+    launch.run_pip("install imageio[ffmpeg]", "requirements for imageio[ffmpeg]")
 
 if not launch.is_installed('ffmpeg'):
     print('Installing requirements for Mov2mov')


### PR DESCRIPTION
报错信息：
ImportError: The `FFMPEG` plugin is not installed. Use `pip install imageio[ffmpeg]` to install it. 
将对应安装语句加入 install.py 中以便安装插件时自动安装对应依赖。