### PR TITLE
New features : Target ControlNet Number to send previous frame

### DIFF
--- a/scripts/m2m_ui.py
+++ b/scripts/m2m_ui.py
@@ -268,7 +268,9 @@ def on_ui_tabs():
                                                      value=30)
 
                     elif category == "seed":
-                        max_frames = gr.Number(label='Max Frames', value=-1, elem_id=f'{id_part}_max_frames')
+                        with FormRow():
+                            max_frames = gr.Number(label='Max Frames', value=-1, elem_id=f'{id_part}_max_frames')
+                            controlnet_num_to_send_previous_frame = gr.Number(label='Target ControlNet Number to send previous frame', value=-1, elem_id=f'{id_part}_controlnet_num_to_send_previous_frame')
                         seed, reuse_seed, subseed, reuse_subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox = create_seed_inputs(
                             'mov2mov')
 
@@ -328,6 +330,7 @@ def on_ui_tabs():
                            denoising_strength,
                            movie_frames,
                            max_frames,
+                           controlnet_num_to_send_previous_frame,
                            seed,
                            subseed, subseed_strength, seed_resize_from_h, seed_resize_from_w, seed_checkbox,
                            height,


### PR DESCRIPTION
직전에 생성된 프레임을 지정된 번호의 ControlNet에 전달
Passes the previously generated frame to ControlNet with the specified number

temporalnet에 이전 프레임을 전송하는 목적 
The purpose of sending previous frames to temporalnet 

temporalnet이 아니여도 가능은 함
You don't have to be temporalnet to do it.