### PR TITLE
Fix video elements height

### DIFF
--- a/scripts/m2m_ui.py
+++ b/scripts/m2m_ui.py
@@ -210,7 +210,7 @@ def on_ui_tabs():
             with gr.Column(variant='compact', elem_id=f"{id_part}_settings"):
                 with gr.Tabs(elem_id=f"mode_{id_part}"):
                     with gr.TabItem('mov2mov', id='mov2mov', elem_id=f"{id_part}_mov2mov_tab") as tab_mov2mov:
-                        init_mov = gr.Video(label="Video for mov2mov", elem_id="{id_part}_mov", show_label=False,
+                        init_mov = gr.Video(label="Video for mov2mov", elem_id=f"{id_part}_mov", show_label=False,
                                             source="upload")  # .style(height=480)
 
                 with FormRow():

--- a/style.css
+++ b/style.css
@@ -125,12 +125,23 @@
     border-radius: 0 0.5rem 0.5rem 0;
 }
 
-#mov2mov_mov {
-    height: 480px !important;
-    max-height: 480px !important;
-    min-height: 480px !important;
+#mov2mov_mov video {
+    height: 480px;
+    max-height: 480px;
+    min-height: 480px;
 }
 
+#mov2mov_video video {
+    height: 480px;
+    max-height: 480px;
+    min-height: 480px;
+}
+
+#modnet_background_movie video {
+    height: 480px;
+    max-height: 480px;
+    min-height: 480px;
+}
 
 #mov2mov_checkboxes {
     margin-bottom: 0.5em;


### PR DESCRIPTION
The changes lock the height of the following HTML video elements to better fit the UI: 
- Input
- Output 
- ModNet 

<br>

<details>
  <summary>Preview of the changes</summary>
  
  ### Before
  ![mov_before](https://user-images.githubusercontent.com/31524206/235008449-d5553eeb-7c05-4f84-905a-d2db93ca0005.png)

  ---
  ### After
  ![mov_after](https://user-images.githubusercontent.com/31524206/235008492-81a832da-04fd-4e2a-85ba-14faef6115f0.png)

</details>

