### PR TITLE
Fix ModNet inputs displaying regardless of mode

### DIFF
--- a/javascript/m2m_ui.js
+++ b/javascript/m2m_ui.js
@@ -31,12 +31,15 @@ function showModnetModels() {
 function switchModnetMode() {
     let mode = arguments[0]
 
-    if (mode === 'Clear' || mode === 'Origin' || mode === 'Green' || mode === 'Image') {
-        gradioApp().getElementById('modnet_background_movie').style.display = "none"
-        gradioApp().getElementById('modnet_background_image').style.display = "block"
+    if (mode === 'Image') {
+        gradioApp().getElementById('modnet_background_movie').style.display = 'none';
+        gradioApp().getElementById('modnet_background_image').style.display = 'block';
+    } else if (mode === 'Movie') {
+        gradioApp().getElementById('modnet_background_image').style.display = 'none';
+        gradioApp().getElementById('modnet_background_movie').style.display = 'block';
     } else {
-        gradioApp().getElementById('modnet_background_movie').style.display = "block"
-        gradioApp().getElementById('modnet_background_image').style.display = "none"
+        gradioApp().getElementById('modnet_background_movie').style.display = 'none';
+        gradioApp().getElementById('modnet_background_image').style.display = 'none';
     }
 
     return []

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@
 /*    display: none;*/
 /*}*/
 
+#modnet_background_image,
 #modnet_background_movie {
     display: none;
 }


### PR DESCRIPTION
The changes make the ModNet image and video inputs hidden by default on the Gradio UI:
- The image input will display only if "Image" mode is selected, no longer for every mode
- The video input will display only if "Movie" mode is selected, same as now

This should make it less confusing to use ModNet by removing inputs that will not be used when enabled