### PR TITLE
Add Movie Editor toggle checkbox

### DIFF
--- a/scripts/mov2mov.py
+++ b/scripts/mov2mov.py
@@ -269,11 +269,11 @@ def mov2mov(id_task: str,
     else:
         # editor
         if platform.system() != 'Windows':
-            raise Exception('The editor is currently only supported on Windows')
+            raise Exception('The Movie Editor is currently only supported on Windows')
 
         # check df no frame
         if not check_data_frame(df):
-            raise Exception('Please add a frame')
+            raise Exception('Please add a frame in the Movie Editor or disable it')
 
         # sort df for index
         df = df.sort_values(by='frame').reset_index(drop=True)

--- a/scripts/movie_editor.py
+++ b/scripts/movie_editor.py
@@ -30,15 +30,19 @@ class MovieEditor:
     def render(self):
         id_part = self.id_part
         with InputAccordion(
-            True, label="Movie Editor", elem_id=f"{id_part}_editor_enable"
-        ) as enable_movie_editor:
-            self.gr_enable_movie_editor = enable_movie_editor
+            True, label="Movie Editor", elem_id=f"{id_part}_editor_accordion"
+        ):
             gr.HTML(
-                "<div style='color:red;font-weight: bold;border: 2px solid yellow;padding: 10px;font-size: 20px; '>"
-                "This feature is in beta version!!! </br>"
-                "It only supports Windows!!! </br>"
-                "Make sure you have installed the controlnet and IP-Adapter models."
+                "<div style='color:red;font-weight: bold;border: 2px solid yellow;padding: 10px;font-size: 20px;'>"
+                "This feature is in beta version!!! <br>"
+                "It only supports Windows!!! <br>"
+                "Make sure you have installed the ControlNet and IP-Adapter models."
                 "</div>"
+            )
+
+            self.gr_enable_movie_editor = gr.Checkbox(
+                label="Enable Movie Editor",
+                elem_id=f"{id_part}_editor_enable",
             )
 
             self.gr_frame_image = gr.Image(


### PR DESCRIPTION
These changes add a checkbox to toggle the activation status of the Movie Editor, along with more context to the Movie Editor errors

We previously used the input accordion to get the activation status by checking whether the Movie Editor section was expanded or collapsed



Should fix https://github.com/Scholar01/sd-webui-mov2mov/issues/110