### PR TITLE
Fix non-functional generate button on 1.8.0

### DIFF
--- a/scripts/m2m_ui.py
+++ b/scripts/m2m_ui.py
@@ -127,6 +127,12 @@ class Toprow:
                         elem_id=f"{id_part}_interrupt",
                         elem_classes="generate-box-interrupt",
                     )
+                    self.interrupting = gr.Button(
+                        "Interrupting...",
+                        elem_id=f"{id_part}_interrupting",
+                        elem_classes="generate-box-interrupting", 
+                        tooltip="Interrupting generation..."
+                    )
                     self.skip = gr.Button(
                         "Skip",
                         elem_id=f"{id_part}_skip",
@@ -143,6 +149,12 @@ class Toprow:
                     )
 
                     self.interrupt.click(
+                        fn=lambda: shared.state.interrupt(),
+                        inputs=[],
+                        outputs=[],
+                    )
+
+                    self.interrupting.click(
                         fn=lambda: shared.state.interrupt(),
                         inputs=[],
                         outputs=[],


### PR DESCRIPTION
This should fix https://github.com/Scholar01/sd-webui-mov2mov/issues/135

I just did a quick test, and it worked on both 1.7.0 and 1.80, but please do proper testing before merging since I have yet to use this extension.

Someone complained on SD Discord that this extension does not work on 1.8.0 and has no errors. So I tried the same thing we did [here](https://github.com/deforum-art/sd-webui-deforum/pull/950), and it worked.

You can check [this](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/9f3ba383143e117601666e4711ceeff2dfda2526) for more info.
