### PR TITLE
Remove the reference to "import groupby"

### DIFF
--- a/ebsynth/ebsynth_generate.py
+++ b/ebsynth/ebsynth_generate.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 from PIL.Image import Image
 from dataclasses import dataclass, field
-from toolz import groupby
+# from toolz import groupby
 
 
 @dataclass


### PR DESCRIPTION
groupby is no longer used in the "ebsynth_generate.py" file, but there is still "from toolz import groupby", An error occurs when installing mov2mov in python v3.10.6 sd-web-ui v1.10.1: "ImportError: cannot import name 'groupby' from 'toolz '", so this pr removes" from toolz import groupby"